### PR TITLE
Add support for specifying the module root.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN git clone https://github.com/sourcegraph/lsif-go.git . && \
 
 FROM golang:1.13.1-buster
 
-LABEL version="0.2.0"
+LABEL version="0.3.0"
 LABEL repository="http://github.com/sourcegraph/lsif-go-action"
 LABEL homepage="http://github.com/sourcegraph/lsif-go-action"
 LABEL maintainer="Sourcegraph Support <support@sourcegraph.com>"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ The following inputs can be set.
 | name         | default   | description |
 | ------------ | --------- | ----------- |
 | file         | dump.lsif | The output file (relative to the repository root). |
-| project_root | `.`       | The root of the project (where go.mod is located). |
+| project_root | `.`       | The root of the repository. |
+| module_root  | `.`       | The directory where `go.mod` is located, relative to the repository. |
 
 The following is a complete example that uses the [upload action](https://github.com/sourcegraph/lsif-upload-action) to upload the generated data to [sourcegraph.com](https://sourcegraph.com). Put this in `.github/workflows/lsif.yaml`.
 

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,10 @@ inputs:
     description: The output filename (relative to the repository root).
     default: dump.lsif
   project_root: 
-    description: The root of the project (where go.mod is located).
+    description: The root of the repository.
+    default: .
+  module_root:
+    description: The directory where go.mod is located (relative to the repository).
     default: .
 
 runs:
@@ -19,3 +22,4 @@ runs:
   env:
     OUT: ${{ inputs.file }}
     PROJECT_ROOT: ${{ inputs.project_root }}
+    MODULE_ROOT: ${{ inputs.module_root }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-if [ -z "$OUT" ]; then
-    echo 'file not supplied.'
-    exit 1
-fi
+: ${OUT:?output file not specified}
+: ${PROJECT_ROOT:?project root not specified}
+: ${MODULE_ROOT:?module root not specified}
 
-ABS_OUT="$(cd "$(dirname "${OUT}")" && pwd)/$(basename "${OUT}")"
+OUTPUT_DIR="$(cd "$(dirname "$OUT")" && pwd)"
+ABS_OUT="${OUTPUT_DIR}/$(basename "$OUT")"
 cd "${PROJECT_ROOT}"
-lsif-go --out "$OUT"
+lsif-go --out "$ABS_OUT" --moduleRoot "$MODULE_ROOT"
 cd -


### PR DESCRIPTION
See also: https://github.com/sourcegraph/lsif-go/pull/51. This change adds a new input to override the module root, and plumbs it through to the indexer.