### PR TITLE
feat: Allow passing additional args to lsif-go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN git clone https://github.com/sourcegraph/lsif-go.git . && \
 
 FROM golang:1.13.1-buster
 
-LABEL version="0.3.0"
+LABEL version="0.4.0"
 LABEL repository="http://github.com/sourcegraph/lsif-go-action"
 LABEL homepage="http://github.com/sourcegraph/lsif-go-action"
 LABEL maintainer="Sourcegraph Support <support@sourcegraph.com>"

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ This action generate LSIF data from Go source code. See the [LSIF go indexer](ht
 
 The following inputs can be set.
 
-| name         | default   | description |
-| ------------ | --------- | ----------- |
-| file         | dump.lsif | The output file (relative to the repository root). |
-| project_root | `.`       | The root of the repository. |
-| module_root  | `.`       | The directory where `go.mod` is located, relative to the repository. |
+| name             | default   | description |
+| ---------------- | --------- | ----------- |
+| file             | dump.lsif | The output file (relative to the repository root). |
+| project_root     | `.`       | The root of the repository. |
+| module_root      | `.`       | The directory where `go.mod` is located, relative to the repository. |
+| additional_args  | ''        | Additional args that are passed directly to `lsif-go`. |
 
 The following is a complete example that uses the [upload action](https://github.com/sourcegraph/lsif-upload-action) to upload the generated data to [sourcegraph.com](https://sourcegraph.com). Put this in `.github/workflows/lsif.yaml`.
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
   module_root:
     description: The directory where go.mod is located (relative to the repository).
     default: .
+  additional_args:
+    description: These arguments are passed directly to lsif-go.
+    default: ''
 
 runs:
   using: docker
@@ -23,3 +26,4 @@ runs:
     OUT: ${{ inputs.file }}
     PROJECT_ROOT: ${{ inputs.project_root }}
     MODULE_ROOT: ${{ inputs.module_root }}
+    ADDITIONAL_ARGS: ${{ intputs.additional_args }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,9 +3,10 @@
 : ${OUT:?output file not specified}
 : ${PROJECT_ROOT:?project root not specified}
 : ${MODULE_ROOT:?module root not specified}
+: ${ADDITIONAL_ARGS=''}
 
 OUTPUT_DIR="$(cd "$(dirname "$OUT")" && pwd)"
 ABS_OUT="${OUTPUT_DIR}/$(basename "$OUT")"
 cd "${PROJECT_ROOT}"
-lsif-go --out "$ABS_OUT" --moduleRoot "$MODULE_ROOT"
+lsif-go --output "$ABS_OUT" --module-root "$MODULE_ROOT" $ADDITIONAL_ARGS
 cd -


### PR DESCRIPTION
Ok, one thing I don't understand at all is how could we be passing `--out` and `--moduleRoot` which don't work on my machine.

When I try to run what is in `entrypoint.sh`, I get the following error (before my changes):

```
❯ OUT=dump.lsif PROJECT_ROOT=/home/tjdevries/sourcegraph/lsif-go.git/master MODULE_ROOT=. ./entrypoint.sh
error: failed to parse args: unknown long flag '--out'
```

And when running manually, I get the same problems:

```
❯ lsif-go --moduleRoot .
error: failed to parse args: unknown long flag '--moduleRoot'
```