### PR TITLE
Bump pr-auditor go version to 1.18

### DIFF
--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
         with: { repository: 'sourcegraph/sourcegraph' }
       - uses: actions/setup-go@v2
-        with: { go-version: '1.17' }
+        with: { go-version: '1.18' }
 
       - run: ./dev/pr-auditor/check-pr.sh
         env:


### PR DESCRIPTION
Fixes failing pr-auditor action runs due to the introduction of `any`.

### Test plan
pr-auditor action completes successfully

[_Created by Sourcegraph batch change `sander.ginn/bump_pr-auditor_go_1.18`._](https://k8s.sgdev.org/users/sander.ginn/batch-changes/bump_pr-auditor_go_1.18)